### PR TITLE
Use built-in crypto instead of sha.js

### DIFF
--- a/lib/abci-app.js
+++ b/lib/abci-app.js
@@ -1,4 +1,4 @@
-let createHash = require('sha.js')
+let { createHash } = require('crypto')
 let abci = require('./abci/')
 let stringify = require('json-stable-stringify')
 let decodeTx = require('./tx-encoding.js').decode

--- a/lib/network-id.js
+++ b/lib/network-id.js
@@ -1,4 +1,4 @@
-let createHash = require('sha.js')
+let { createHash } = require('crypto')
 
 module.exports = function generateNetworkId(...args) {
   let networkId = createHash('sha256')

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "memdown": "^1.2.4",
     "pkg": "^4.2.2",
     "protobufjs": "~5.0.1",
-    "sha.js": "^2.4.8",
     "tendermint-keys": "^2.0.2",
     "unzip": "^0.1.11",
     "varstruct": "^6.1.1",


### PR DESCRIPTION
sha.js is a pure JS lib, so there's no benefit in using that over the built-in node crypto module if we're not targeting browsers.