### PR TITLE
Get expectedRootHash from liteClient's state rather than waitfor update

### DIFF
--- a/example/counter/app.js
+++ b/example/counter/app.js
@@ -19,9 +19,9 @@ app.use((state, tx) => {
   state.count++
 })
 
-app.useBlock(state => {
-  state.blockCount++
-})
+// app.useBlock(state => {
+//   state.blockCount++
+// })
 
 app.listen(port).then(({ GCI }) => {
   console.log(GCI)

--- a/example/counter/app.js
+++ b/example/counter/app.js
@@ -9,7 +9,9 @@ let app = require('../../')({
   peers: ['localhost:46660'],
   tendermintPort: 46657,
   p2pPort: 46661,
-  devMode: true
+  devMode: true,
+  createEmptyBlocks: true,
+  createEmptyBlocksInterval: 5,
 })
 
 app.use((state, tx) => {

--- a/example/counter/app0.js
+++ b/example/counter/app0.js
@@ -1,16 +1,15 @@
-let initialState = { count: 0, blockCount: 0, foo: { bar: { beep: 'boop' } }, height: 0, txHeight: 0, lastMatch: 0 }
+let initialState = { count: 0, blockCount: 0, foo: { bar: { beep: 'boop' } }, height: 0, txHeight: 0, lastMatch: 0  }
 let axios = require('axios')
 
-let port = 3000
+let port = 3001
 let opts = {
   initialState,
   genesis: 'genesis.json',
-  keys: 'keys.json',
+  keys: 'keys2.json',
   logTendermint: true,
-  peers: ['localhost:46660'],
-  tendermintPort: 46657,
-  p2pPort: 46661,
-  abciPort: 46662,
+  peers: ['localhost:46661'],
+  tendermintPort: 46658,
+  p2pPort: 46660,
   devMode: true,
   createEmptyBlocks: true,
   createEmptyBlocksInterval: 5,

--- a/example/counter/txtest.js
+++ b/example/counter/txtest.js
@@ -1,0 +1,14 @@
+let axios = require('axios')
+
+let url = 'http://localhost:3000'
+
+
+async function main() {
+  axios.post(url + '/txs', {})
+  axios.post(url + '/txs', {})
+  axios.post(url + '/txs', {})
+  axios.post(url + '/txs', {})
+  axios.post(url + '/txs', {})
+}
+
+main()

--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ function Lotion(opts = {}) {
     typeof opts.createEmptyBlocks === 'undefined'
       ? true
       : opts.createEmptyBlocks
+  let createEmptyBlocksInterval = opts.createEmptyBlocksInterval || 0
+  console.log("Interval:" + createEmptyBlocksInterval)
   let target = opts.target
   let devMode = opts.devMode || false
   let lite = opts.lite || false
@@ -178,6 +180,7 @@ function Lotion(opts = {}) {
             p2pPort,
             logTendermint,
             createEmptyBlocks,
+            createEmptyBlocksInterval,
             networkId,
             peers,
             genesis,

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ let get = require('lodash.get')
 function waitForHeight(height, lc) {
   return new Promise((resolve, reject) => {
     function handleUpdate(header) {
-      if (header.height > height) {
+      if (header.height >= height) {
         resolve()
         lc.removeListener('update', handleUpdate)
       }
@@ -323,8 +323,14 @@ Lotion.connect = function(GCI, opts = {}) {
         } catch (e) {
           throw new Error('invalid json in query response')
         }
-        await waitForHeight(resp.height, lc)
-        let expectedRootHash = appHashByHeight[resp.height].toLowerCase()
+
+        let lcState = lc.state()
+
+        if (lcState.header.height != resp.height) {
+          await waitForHeight(resp.height, lc)
+        }
+
+        let expectedRootHash = lcState.header.app_hash.toLowerCase()
         let rootHash = (await getRoot(value)).toString('hex')
         if (rootHash !== expectedRootHash) {
           throw new Error(

--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ function Lotion(opts = {}) {
       ? true
       : opts.createEmptyBlocks
   let createEmptyBlocksInterval = opts.createEmptyBlocksInterval || 0
-  console.log("Interval:" + createEmptyBlocksInterval)
   let target = opts.target
   let devMode = opts.devMode || false
   let lite = opts.lite || false

--- a/lib/tendermint.js
+++ b/lib/tendermint.js
@@ -79,13 +79,10 @@ module.exports = function({
     }
 
     if (createEmptyBlocksInterval>0) {
-      require('fs').appendFile(join(lotionPath, 'config.toml'), '[consensus]\ncreate_empty_blocks_interval = '+createEmptyBlocksInterval, function (err) {
+      require('fs').appendFile(join(lotionPath, 'config.toml'), '[consensus]\ncreate_empty_blocks_interval='+createEmptyBlocksInterval, function (err) {
         if (err) throw err;
-        console.log('config.toml saved!');
       });
     }
-
-    console.log(tpArgs)
 
     let shuttingDown = false
     let tendermintProcess = execa(tmBin, tpArgs, {

--- a/lib/tendermint.js
+++ b/lib/tendermint.js
@@ -25,6 +25,7 @@ module.exports = function({
   keys,
   initialAppHash,
   createEmptyBlocks,
+  createEmptyBlocksInterval,
   unsafeRpc
 }) {
   return new Promise(async (resolveNodeRunning, rejectNodeRunning) => {
@@ -76,6 +77,15 @@ module.exports = function({
     if (createEmptyBlocks === false) {
       tpArgs.push('--consensus.create_empty_blocks=false')
     }
+
+    if (createEmptyBlocksInterval>0) {
+      require('fs').appendFile(join(lotionPath, 'config.toml'), '[consensus]\ncreate_empty_blocks_interval = '+createEmptyBlocksInterval, function (err) {
+        if (err) throw err;
+        console.log('config.toml saved!');
+      });
+    }
+
+    console.log(tpArgs)
 
     let shuttingDown = false
     let tendermintProcess = execa(tmBin, tpArgs, {

--- a/lib/tendermint.js
+++ b/lib/tendermint.js
@@ -79,7 +79,11 @@ module.exports = function({
     }
 
     if (createEmptyBlocksInterval>0) {
-      require('fs').appendFile(join(lotionPath, 'config.toml'), '[consensus]\ncreate_empty_blocks_interval='+createEmptyBlocksInterval, function (err) {
+      config_lines =  `
+[consensus]
+create_empty_blocks_interval = ${createEmptyBlocksInterval}
+`
+      require('fs').appendFile(join(lotionPath, 'config.toml'), config_lines, function (err) {
         if (err) throw err;
       });
     }


### PR DESCRIPTION
Not sure whether this is a completely correct way to do it, but as described in the commit:
Instead of waiting until the liteClient received an update (which can take a while depending on if empty blocks are created and their interval) - we check whether the liteClient's current `lc.state().header.height` is equal to the polled state's height.
If the height is equal we proceed comparing `lc.state().header.app_hash` to the rootHash of the polled state's data.
If the heights are different we do the previous procedure of waiting for an update from the chain.