### PR TITLE
Added block info to chainInfo object

### DIFF
--- a/lib/abci-app.js
+++ b/lib/abci-app.js
@@ -104,6 +104,11 @@ module.exports = function configureABCIServer({
     }
   }
 
+  abciApp.beginBlock = function(req, cb) {
+    chainInfo.block = req.begin_block
+    cb({})
+  }
+
   abciApp.commit = async function() {
     chainInfo.height++
     blockMiddleware.forEach(blockHandler => {


### PR DESCRIPTION
As discussed earlier, this is the corresponding pull request for having the information from the begin_block request in the chainInfo object.