### PR TITLE
Tendermint 0.31.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4628,7 +4628,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4639,7 +4639,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -6762,7 +6762,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6773,7 +6773,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -7723,7 +7723,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7734,7 +7734,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -8189,9 +8189,9 @@
       }
     },
     "tendermint-node": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-5.0.2.tgz",
-      "integrity": "sha512-ww5wkZwwOHe04JClRcLSY8kmevI8OjGHpbfk+1rbvlTUnOrYa+Aok0Z4K+femJQBmjJmc6583BG0827OGnz5fw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-5.1.1.tgz",
+      "integrity": "sha512-2c13CjfDzsGuZFvO7tSJdw4ymlnekpVCg++6pKxTWfObAfluxy9yTQ+B71Y+DufjXB4rEvn6N3X/NPiXKu0OJQ==",
       "requires": {
         "axios": "^0.18.0",
         "cross-spawn": "^6.0.5",
@@ -8536,7 +8536,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8547,7 +8547,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -353,9 +353,9 @@
       "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q=="
     },
     "abci": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/abci/-/abci-4.0.2.tgz",
-      "integrity": "sha512-T3YTyu9pJOfluEw/KXYWv3qeIe3TR+iSAEmFnIQK0ZnbrgyZjGv3ClF97EjHBDelnE5mS++OPTON37/ldiH/NA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abci/-/abci-5.0.1.tgz",
+      "integrity": "sha512-fUqeJAbIZCAW85Q2HZ49/W6tkqPyhBBbhflJpLWuJI10rXZxO9kvwCWXW1aPoLskztyK2ocsPPWPymMQAC8S8Q==",
       "requires": {
         "bl": "^1.2.2",
         "debug": "^3.1.0",
@@ -803,11 +803,11 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "^1.3.0",
+        "follow-redirects": "^1.2.5",
         "is-buffer": "^1.1.5"
       }
     },
@@ -1396,7 +1396,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -3443,6 +3443,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7415,11 +7416,26 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -8155,9 +8171,9 @@
       "dev": true
     },
     "tendermint": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-3.4.0.tgz",
-      "integrity": "sha512-am7uo+SvSQq3tT/DcrpNSDMqq3i6JWriSi5qAAJgChfGWb23Ms1dKYxae1pNptPbfiLsFR4qUkxGmeNBF8Owkg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-4.0.2.tgz",
+      "integrity": "sha512-bGvLuvk8JBGXgw5m4GQfRmXNENiqwQyymqYAh/DwtN0X7f9SNZouhRt4Vh3WHkfOoO3sFGCie0PqbhumKkucGg==",
       "requires": {
         "axios": "^0.17.1",
         "camelcase": "^4.0.0",
@@ -8170,23 +8186,12 @@
         "supercop.js": "^2.0.1",
         "varstruct": "^6.1.1",
         "websocket-stream": "^5.1.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.17.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-          "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-          "requires": {
-            "follow-redirects": "^1.2.5",
-            "is-buffer": "^1.1.5"
-          }
-        }
       }
     },
     "tendermint-node": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-3.5.0.tgz",
-      "integrity": "sha512-xSkWNlB5RosIWewhE+cPb9TFesZ+m9qO5zxH+Lby9ptKOdhUCWPRuaPf37ksHX65VvZ1kJ+FgeWOPSPkWnhgDA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-5.0.2.tgz",
+      "integrity": "sha512-ww5wkZwwOHe04JClRcLSY8kmevI8OjGHpbfk+1rbvlTUnOrYa+Aok0Z4K+femJQBmjJmc6583BG0827OGnz5fw==",
       "requires": {
         "axios": "^0.18.0",
         "cross-spawn": "^6.0.5",
@@ -8195,8 +8200,19 @@
         "execa": "^0.10.0",
         "mkdirp": "^0.5.1",
         "progress": "^2.0.0",
-        "tendermint": "^3.1.3",
+        "tendermint": "^4.0.0",
         "unzip": "^0.1.11"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+          "requires": {
+            "follow-redirects": "^1.3.0",
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/node": "^10.5.2",
-    "abci": "^4.0.2",
+    "abci": "^5.0.1",
     "deterministic-json": "^1.0.5",
     "fs-extra": "^7.0.0",
     "get-port": "^4.0.0",
@@ -20,8 +20,8 @@
     "lotion-connect": "^0.1.9",
     "lotion-state-machine": "^0.2.0",
     "peer-channel": "^0.1.2",
-    "tendermint": "^3.4.0",
-    "tendermint-node": "^3.5.0",
+    "tendermint": "^4.0.2",
+    "tendermint-node": "^5.0.2",
     "varstruct": "^6.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lotion-state-machine": "^0.2.0",
     "peer-channel": "^0.1.2",
     "tendermint": "^4.0.2",
-    "tendermint-node": "^5.0.2",
+    "tendermint-node": "^5.1.1",
     "varstruct": "^6.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to `tendermint-node@5.1.1` to target Tendermint 0.31.5.

This should be published in step with https://github.com/nomic-io/lotion-connect/pull/7 (update the `lotion-connect` dependency to that version when publishing this).