### PR TITLE
Simplify peer discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,9 +2310,9 @@
       }
     },
     "dns-discovery": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/dns-discovery/-/dns-discovery-6.2.2.tgz",
-      "integrity": "sha512-EZQxH4I5ZAQbV8Njlb4JXhgeIKtcXdCzLCLSJIyzEXbzEm6hNsJdX5F6oW+4a02etsaSPBX3iEDFyPg7VB91PQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/dns-discovery/-/dns-discovery-6.2.3.tgz",
+      "integrity": "sha512-ZULG1R5J9QHZfaXo5XFGVG22LIcnZorbEa7f83FYgCGDaQrVfyVmty3Z89OvBLpCPetwW+LzjCcT60ekhbQ+9g==",
       "requires": {
         "circular-append-file": "^1.0.1",
         "debug": "^2.6.9",
@@ -4302,9 +4302,9 @@
       },
       "dependencies": {
         "bencode": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.0.tgz",
-          "integrity": "sha512-wr2HwwrUpfB5c68zmAudOltC7rZ1G0+lQOcnuEcfIM3AWAVnB3rHI3nlgd/2CWTfQ3w3zagKt89zni/M+VLZ8g==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.1.tgz",
+          "integrity": "sha512-2uhEl8FdjSBUyb69qDTgOEeeqDTa+n3yMQzLW0cOzNf1Ow5bwcg3idf+qsWisIKRH8Bk8oC7UXL8irRcPA8ZEQ==",
           "requires": {
             "safe-buffer": "^5.1.1"
           }
@@ -4832,9 +4832,9 @@
       },
       "dependencies": {
         "thunky": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
-          "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+          "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow=="
         }
       }
     },
@@ -7638,9 +7638,9 @@
       }
     },
     "simple-sha1": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.1.tgz",
-      "integrity": "sha512-pFMPd+I/lQkpf4wFUeS/sED5IqdIG1lUlrQviBMV4u4mz8BRAcB5fvUx5Ckfg3kBigEglAjHg7E9k/yy2KlCqA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.2.tgz",
+      "integrity": "sha512-TQl9rm4rdKAVmhO++sXAb8TNN0D6JAD5iyI1mqEPNpxUzTRrtm4aOG1pDf/5W/qCFihiaoK6uuL9rvQz1x1VKw==",
       "requires": {
         "rusha": "^0.8.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4628,7 +4628,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4639,7 +4639,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -6762,7 +6762,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6773,7 +6773,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -7723,7 +7723,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7734,7 +7734,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -8189,9 +8189,9 @@
       }
     },
     "tendermint-node": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-5.0.2.tgz",
-      "integrity": "sha512-ww5wkZwwOHe04JClRcLSY8kmevI8OjGHpbfk+1rbvlTUnOrYa+Aok0Z4K+femJQBmjJmc6583BG0827OGnz5fw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-5.1.1.tgz",
+      "integrity": "sha512-2c13CjfDzsGuZFvO7tSJdw4ymlnekpVCg++6pKxTWfObAfluxy9yTQ+B71Y+DufjXB4rEvn6N3X/NPiXKu0OJQ==",
       "requires": {
         "axios": "^0.18.0",
         "cross-spawn": "^6.0.5",
@@ -8536,7 +8536,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8547,7 +8547,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -353,9 +353,9 @@
       "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q=="
     },
     "abci": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/abci/-/abci-4.0.2.tgz",
-      "integrity": "sha512-T3YTyu9pJOfluEw/KXYWv3qeIe3TR+iSAEmFnIQK0ZnbrgyZjGv3ClF97EjHBDelnE5mS++OPTON37/ldiH/NA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abci/-/abci-5.0.1.tgz",
+      "integrity": "sha512-fUqeJAbIZCAW85Q2HZ49/W6tkqPyhBBbhflJpLWuJI10rXZxO9kvwCWXW1aPoLskztyK2ocsPPWPymMQAC8S8Q==",
       "requires": {
         "bl": "^1.2.2",
         "debug": "^3.1.0",
@@ -803,11 +803,11 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "^1.3.0",
+        "follow-redirects": "^1.2.5",
         "is-buffer": "^1.1.5"
       }
     },
@@ -1396,7 +1396,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -3443,6 +3443,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7415,11 +7416,26 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -8155,9 +8171,9 @@
       "dev": true
     },
     "tendermint": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-3.4.0.tgz",
-      "integrity": "sha512-am7uo+SvSQq3tT/DcrpNSDMqq3i6JWriSi5qAAJgChfGWb23Ms1dKYxae1pNptPbfiLsFR4qUkxGmeNBF8Owkg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-4.0.2.tgz",
+      "integrity": "sha512-bGvLuvk8JBGXgw5m4GQfRmXNENiqwQyymqYAh/DwtN0X7f9SNZouhRt4Vh3WHkfOoO3sFGCie0PqbhumKkucGg==",
       "requires": {
         "axios": "^0.17.1",
         "camelcase": "^4.0.0",
@@ -8170,23 +8186,12 @@
         "supercop.js": "^2.0.1",
         "varstruct": "^6.1.1",
         "websocket-stream": "^5.1.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.17.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-          "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-          "requires": {
-            "follow-redirects": "^1.2.5",
-            "is-buffer": "^1.1.5"
-          }
-        }
       }
     },
     "tendermint-node": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-3.5.0.tgz",
-      "integrity": "sha512-xSkWNlB5RosIWewhE+cPb9TFesZ+m9qO5zxH+Lby9ptKOdhUCWPRuaPf37ksHX65VvZ1kJ+FgeWOPSPkWnhgDA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/tendermint-node/-/tendermint-node-5.0.2.tgz",
+      "integrity": "sha512-ww5wkZwwOHe04JClRcLSY8kmevI8OjGHpbfk+1rbvlTUnOrYa+Aok0Z4K+femJQBmjJmc6583BG0827OGnz5fw==",
       "requires": {
         "axios": "^0.18.0",
         "cross-spawn": "^6.0.5",
@@ -8195,8 +8200,19 @@
         "execa": "^0.10.0",
         "mkdirp": "^0.5.1",
         "progress": "^2.0.0",
-        "tendermint": "^3.1.3",
+        "tendermint": "^4.0.0",
         "unzip": "^0.1.11"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+          "requires": {
+            "follow-redirects": "^1.3.0",
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/node": "^10.5.2",
-    "abci": "^4.0.2",
+    "abci": "^5.0.1",
     "deterministic-json": "^1.0.5",
     "fs-extra": "^7.0.0",
     "get-port": "^4.0.0",
@@ -20,8 +20,8 @@
     "lotion-connect": "^0.1.9",
     "lotion-state-machine": "^0.2.0",
     "peer-channel": "^0.1.2",
-    "tendermint": "^3.4.0",
-    "tendermint-node": "^3.5.0",
+    "tendermint": "^4.0.2",
+    "tendermint-node": "^5.0.2",
     "varstruct": "^6.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lotion-state-machine": "^0.2.0",
     "peer-channel": "^0.1.2",
     "tendermint": "^4.0.2",
-    "tendermint-node": "^5.0.2",
+    "tendermint-node": "^5.1.1",
     "varstruct": "^6.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,11 @@
     "@types/node": "^10.5.2",
     "abci": "^5.0.1",
     "deterministic-json": "^1.0.5",
+    "discovery-channel": "^5.5.1",
     "fs-extra": "^7.0.0",
     "get-port": "^4.0.0",
-    "jpfs": "0.0.4",
     "lotion-connect": "^0.1.9",
     "lotion-state-machine": "^0.2.0",
-    "peer-channel": "^0.1.2",
     "tendermint": "^4.0.2",
     "tendermint-node": "^5.1.1",
     "varstruct": "^6.1.2"

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1,17 +1,4 @@
-let { createServer } = require('peer-channel')
-let { serve } = require('jpfs')
-
-function announce(GCI: string, rpcPort: number) {
-  let server = createServer(function(socket) {
-    socket.send('' + rpcPort)
-    socket.end()
-
-    socket.on('error', e => {})
-  })
-
-  server.listen('fullnode:' + GCI)
-  return server
-}
+let DC = require('discovery-channel')
 
 export interface DiscoveryServer {
   close()
@@ -19,18 +6,15 @@ export interface DiscoveryServer {
 
 interface DiscoveryInfo {
   GCI: string
-  genesis: string
   rpcPort: number
 }
 
-export default function(info: DiscoveryInfo) {
-  let announceServer = announce(info.GCI, info.rpcPort)
-  let genesisServer = serve(info.genesis)
-
+export default function(info: DiscoveryInfo): DiscoveryServer {
+  let channel = DC()
+  channel.join(info.GCI, info.rpcPort)
   return {
     close() {
-      announceServer.close()
-      genesisServer.close()
+      channel.destroy()
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import createDiscoveryServer, { DiscoveryServer } from './discovery'
 import { randomBytes, createHash } from 'crypto'
 import fs = require('fs-extra')
 import getPort = require('get-port')
+import DJSON = require('deterministic-json')
 
 interface ApplicationConfig extends BaseApplicationConfig {
   rpcPort?: number
@@ -98,7 +99,9 @@ class LotionApp implements Application {
     if (!this.genesisPath) {
       this.genesisPath = join(this.home, 'config', 'genesis.json')
     }
-    this.genesis = fs.readFileSync(this.genesisPath, 'utf8')
+    let genesisJSON = fs.readFileSync(this.genesisPath, 'utf8')
+    let parsedGenesis = JSON.parse(genesisJSON)
+    this.genesis = DJSON.stringify(parsedGenesis)
   }
 
   private setHome() {
@@ -149,13 +152,10 @@ class LotionApp implements Application {
     this.setGCI()
 
     // start discovery server
-    if (this.discovery) {
-      this.discoveryServer = createDiscoveryServer({
-        GCI: this.GCI,
-        genesis: this.genesis,
-        rpcPort: this.ports.rpc
-      })
-    }
+    this.discoveryServer = createDiscoveryServer({
+      GCI: this.GCI,
+      rpcPort: this.ports.rpc
+    })
 
     let appInfo = this.getAppInfo()
 

--- a/src/tendermint.ts
+++ b/src/tendermint.ts
@@ -113,14 +113,23 @@ export default async function createTendermintProcess({
       fs.copySync(keyPath, privValPath)
     }
   }
+
+  let closing = false
+
   let tendermintProcess = tendermint.node(home, opts)
   if (logTendermint) {
     tendermintProcess.stdout.pipe(process.stdout)
     tendermintProcess.stderr.pipe(process.stderr)
   }
   tendermintProcess.then(() => {
+    if (closing) return
     throw new Error('Tendermint exited unexpectedly')
   })
   await tendermintProcess.synced()
-  return {}
+  return {
+    close () {
+      closing = true
+      tendermintProcess.kill()
+    }
+  }
 }


### PR DESCRIPTION
This PR simplifies the peer discovery stack and makes some reliability improvements, but overall maintains the same functionality.

- Removes `jpfs` dependency in favor of serving genesis file via RPC
- Removes `peer-channel` dependency in favor of announcing RPC services through `discovery-peer`
- Use `deterministic-json` to derive genesis hash for GCI

Should be published in step with https://github.com/nomic-io/lotion-connect/pull/8 (update the `lotion-connect` dependency when publishing this).