### PR TITLE
Merklized state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,7 +4205,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4216,7 +4216,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -4294,6 +4294,28 @@
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
+        }
+      }
+    },
+    "merk": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/merk/-/merk-1.3.4.tgz",
+      "integrity": "sha512-SnB1QTwDMvKGVtGXLmB6Cdw/2npcPaXUgMvE43UxoSrY47537s8vpQGMGR9MNvhYTwoal8URaseOskJZBBxg8Q==",
+      "requires": {
+        "create-hash": "^1.1.3",
+        "deterministic-json": "^1.0.4",
+        "old": "^0.2.0",
+        "varint": "^5.0.0",
+        "varstruct": "^6.1.1"
+      },
+      "dependencies": {
+        "old": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/old/-/old-0.2.0.tgz",
+          "integrity": "sha1-rnWp8zuufLP+BjEombeuWnO6JO8=",
+          "requires": {
+            "object-assign": "^4.1.0"
+          }
         }
       }
     },
@@ -6251,7 +6273,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6262,7 +6284,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -7054,7 +7076,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7065,7 +7087,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -7810,7 +7832,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7821,7 +7843,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4456,9 +4456,9 @@
       }
     },
     "merk": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/merk/-/merk-1.3.4.tgz",
-      "integrity": "sha512-SnB1QTwDMvKGVtGXLmB6Cdw/2npcPaXUgMvE43UxoSrY47537s8vpQGMGR9MNvhYTwoal8URaseOskJZBBxg8Q==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/merk/-/merk-1.3.6.tgz",
+      "integrity": "sha512-DP0pNmR/0zDSdztkUdef+r7Rtv3xO4uCy1XhGD9Y4VC4JGI3Wr+5x0NtLhQha3vvX8JLHM5rUlouqCQKxcAtPA==",
       "requires": {
         "create-hash": "^1.1.3",
         "deterministic-json": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4251,9 +4251,9 @@
       }
     },
     "lotion-state-machine": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/lotion-state-machine/-/lotion-state-machine-0.2.0.tgz",
-      "integrity": "sha512-p1oEzQEM7/Y+PSymp9My2jPM3sGZkZQFCE8z/zT9imlILCWjSedwVxYCHVUq7cEQLmARv27iS0pGuk8aEfwcmQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/lotion-state-machine/-/lotion-state-machine-0.2.1.tgz",
+      "integrity": "sha512-Xsubaqih7ulYCu5m0u8dhFwNBfeu8KzHYEuuAgzq/YabKkab0LG2l6Uq9BQ/JCQQd3ZAHrnCSwaRcGjF91ZlbQ==",
       "requires": {
         "@types/node": "^10.5.2",
         "deterministic-json": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,15 @@
         "protocol-buffers-encodings": "^1.1.0"
       }
     },
+    "abstract-leveldown": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
+      "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
+      "requires": {
+        "level-concat-iterator": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -2025,6 +2034,15 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "deferred-leveldown": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz",
+      "integrity": "sha512-BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==",
+      "requires": {
+        "abstract-leveldown": "~6.0.0",
+        "inherits": "^2.0.3"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2265,6 +2283,17 @@
         "core-js": "^2.0.0"
       }
     },
+    "encoding-down": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.0.2.tgz",
+      "integrity": "sha512-oAEANslmNb64AF4kvHXjTxB7KecwD7X0qf8MffMfhpjP6gjGcnCTOkRgps/1yUNeR4Bhe6ckN6aAzZz+RIYgTw==",
+      "requires": {
+        "abstract-leveldown": "^6.0.0",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -2278,6 +2307,14 @@
       "resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
       "integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
       "dev": true
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2406,6 +2443,11 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
+    },
+    "fast-future": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
     },
     "figures": {
       "version": "2.0.0",
@@ -3392,6 +3434,11 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
+    "immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -3716,6 +3763,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
@@ -3937,6 +3989,107 @@
         "invert-kv": "^2.0.0"
       }
     },
+    "level": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
+      "integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
+      "requires": {
+        "level-js": "^4.0.0",
+        "level-packager": "^5.0.0",
+        "leveldown": "^5.0.0",
+        "opencollective-postinstall": "^2.0.0"
+      }
+    },
+    "level-codec": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
+    },
+    "level-concat-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
+    },
+    "level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz",
+      "integrity": "sha512-pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.2",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "level-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.1.tgz",
+      "integrity": "sha512-m5JRIyHZn5VnCCFeRegJkn5bQd3MJK5qZX12zg3Oivc8+BUIS2yFS6ANMMeHX2ieGxucNvEn6/ZnyjmZQLLUWw==",
+      "requires": {
+        "abstract-leveldown": "~6.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "^2.0.3",
+        "ltgt": "^2.1.2",
+        "typedarray-to-buffer": "~3.1.5"
+      }
+    },
+    "level-packager": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.0.1.tgz",
+      "integrity": "sha512-tigB8g7xnFE5es2d/OmGJvcJC9S+FQfJnnULSLbPr53/ABPIaCarCxofkwdBhnJxjLZCNvj/Je6luFj/XeuaUQ==",
+      "requires": {
+        "encoding-down": "^6.0.0",
+        "levelup": "^4.0.0"
+      }
+    },
+    "leveldown": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.0.3.tgz",
+      "integrity": "sha512-isfWtOQIXbGbQRI8nmU9FqCZM0klmqTAOFi0vF6G/D0O1ZgxLrSh6Xd4Zj9iVQfGt6+8jpYwkRbN07VLrxRM8w==",
+      "requires": {
+        "abstract-leveldown": "~6.0.3",
+        "fast-future": "~1.0.2",
+        "napi-macros": "~1.8.1",
+        "node-gyp-build": "~3.8.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
+          "integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw=="
+        }
+      }
+    },
+    "levelup": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.1.tgz",
+      "integrity": "sha512-l7KXOkINXHgNqmz0v9bxvRnMCUG4gmShFrzFSZXXhcqFnfvKAW8NerVsTICpZtVhGOMAmhY6JsVoVh/tUPBmdg==",
+      "requires": {
+        "deferred-leveldown": "~5.0.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -4141,6 +4294,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -4487,6 +4645,11 @@
           "dev": true
         }
       }
+    },
+    "napi-macros": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
+      "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg=="
     },
     "natives": {
       "version": "1.1.6",
@@ -5813,6 +5976,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
+    },
     "option-chain": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
@@ -6248,6 +6416,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxmise/-/proxmise-1.1.0.tgz",
       "integrity": "sha512-jvUled+GELUjHqmU2Q65/9KpY7XWstT+bcBndvmNQU5lTmBpzmbpc09ABDzeMP51QHAqxTbA7h7CM9NAKtB7Tg=="
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -7683,6 +7856,14 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typescript": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "get-port": "^4.0.0",
     "level": "^5.0.1",
     "lotion-connect": "^0.1.15",
-    "lotion-state-machine": "^0.2.0",
+    "lotion-state-machine": "^0.2.1",
     "merk": "^1.3.6",
     "tendermint": "^4.0.2",
     "tendermint-node": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "discovery-channel": "^5.5.1",
     "fs-extra": "^7.0.0",
     "get-port": "^4.0.0",
+    "level": "^5.0.1",
     "lotion-connect": "^0.1.15",
     "lotion-state-machine": "^0.2.0",
     "merk": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "level": "^5.0.1",
     "lotion-connect": "^0.1.15",
     "lotion-state-machine": "^0.2.0",
-    "merk": "^1.3.4",
+    "merk": "^1.3.6",
     "tendermint": "^4.0.2",
     "tendermint-node": "^5.1.1",
     "varstruct": "^6.1.2"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "get-port": "^4.0.0",
     "lotion-connect": "^0.1.15",
     "lotion-state-machine": "^0.2.0",
+    "merk": "^1.3.4",
     "tendermint": "^4.0.2",
     "tendermint-node": "^5.1.1",
     "varstruct": "^6.1.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { randomBytes, createHash } from 'crypto'
 import fs = require('fs-extra')
 import getPort = require('get-port')
 import DJSON = require('deterministic-json')
+import merk = require('merk')
 
 interface ApplicationConfig extends BaseApplicationConfig {
   rpcPort?: number
@@ -38,6 +39,8 @@ interface AppInfo {
 }
 
 class LotionApp implements Application {
+  private db: any
+  private state: any
   private stateMachine: StateMachine
   private application: Application
   private abciServer: ABCIServer
@@ -128,10 +131,14 @@ class LotionApp implements Application {
     await this.assignPorts()
     await fs.mkdirp(this.home)
 
+    this.db = level(join(this.home, 'state.db'))
+    this.state = await merk(this.db)
+
     // start state machine
     this.stateMachine = this.application.compile()
 
     this.abciServer = createABCIServer(
+      this.state,
       this.stateMachine,
       this.initialState,
       this.home

--- a/test/testnet.js
+++ b/test/testnet.js
@@ -54,6 +54,7 @@ test('counter app testnet', async function(t) {
   let a = await startApp(nodeA)
   let aRpc = RpcClient(`localhost:${nodeA.rpcPort}`)
   let status = await aRpc.status()
+  console.log('started a')
 
   let b = await startApp({
     ...nodeB,
@@ -64,7 +65,8 @@ test('counter app testnet', async function(t) {
 
   status = await bRpc.status()
   let bPubKey = status.validator_info.pub_key.value
-  t.true(status.sync_info.latest_block_height > 1)
+  t.true(status.sync_info.latest_block_height >= 1)
+  console.log('started b')
 
   let alc = await lotion.connect(
     null,
@@ -73,6 +75,7 @@ test('counter app testnet', async function(t) {
       nodes: [`ws://localhost:${nodeA.rpcPort}`]
     }
   )
+  console.log('connected to a')
   let blc = await lotion.connect(
     null,
     {
@@ -80,17 +83,22 @@ test('counter app testnet', async function(t) {
       nodes: [`ws://localhost:${nodeB.rpcPort}`]
     }
   )
+  console.log('connected to b')
 
   await blc.send({ pubKey: bPubKey })
+  console.log('send tx')
 
   let txCount = await alc.state.txCount
   t.is(txCount, 1)
+  console.log('got state')
 
   await Promise.all([alc.send({ letter: 'a' }), blc.send({ letter: 'b' })])
   t.is(await alc.state.txCount, 3)
   t.true((await alc.state.blockCount) > 0)
+  console.log('sent more txs')
 
   t.is(await alc.state.word, await blc.state.word)
+  console.log('got state')
 })
 
 function delay(ms = 1000) {

--- a/test/testnet.js
+++ b/test/testnet.js
@@ -54,7 +54,6 @@ test('counter app testnet', async function(t) {
   let a = await startApp(nodeA)
   let aRpc = RpcClient(`localhost:${nodeA.rpcPort}`)
   let status = await aRpc.status()
-  console.log('started a')
 
   let b = await startApp({
     ...nodeB,
@@ -66,7 +65,6 @@ test('counter app testnet', async function(t) {
   status = await bRpc.status()
   let bPubKey = status.validator_info.pub_key.value
   t.true(status.sync_info.latest_block_height >= 1)
-  console.log('started b')
 
   let alc = await lotion.connect(
     null,
@@ -75,7 +73,6 @@ test('counter app testnet', async function(t) {
       nodes: [`ws://localhost:${nodeA.rpcPort}`]
     }
   )
-  console.log('connected to a')
   let blc = await lotion.connect(
     null,
     {
@@ -83,22 +80,17 @@ test('counter app testnet', async function(t) {
       nodes: [`ws://localhost:${nodeB.rpcPort}`]
     }
   )
-  console.log('connected to b')
 
   await blc.send({ pubKey: bPubKey })
-  console.log('send tx')
 
   let txCount = await alc.state.txCount
   t.is(txCount, 1)
-  console.log('got state')
 
   await Promise.all([alc.send({ letter: 'a' }), blc.send({ letter: 'b' })])
   t.is(await alc.state.txCount, 3)
   t.true((await alc.state.blockCount) > 0)
-  console.log('sent more txs')
 
   t.is(await alc.state.word, await blc.state.word)
-  console.log('got state')
 })
 
 function delay(ms = 1000) {


### PR DESCRIPTION
Updated to use merkle tree for state, produce merkle proofs for ABCI queries, and persist state inside a `leveldb` via `merk`.

Publish along with https://github.com/nomic-io/lotion-connect/pull/9 (update `lotion-connect` dep to use that PR's changes).

